### PR TITLE
Fix instruction errors in `labs/intro/python/lab-02`

### DIFF
--- a/labs/intro/python/lab-02/README.md
+++ b/labs/intro/python/lab-02/README.md
@@ -8,6 +8,7 @@ Create a new empty directory, and create a new pulumi project called `stack-1
 
 ```bash
 mkdir stack-1
+cd stack-1
 pulumi new python
 ```
 
@@ -40,7 +41,7 @@ error: Missing required configuration variable 'stack-1:required_value'
 Set the configuration option that is missing:
 
 ```bash
-pulumi config set required_value = "i-am-required"
+pulumi config set required_value "i-am-required"
 ```
 
 Re-run `pulumi up` and see that your pulumi program runs successfully, but there's no output.


### PR DESCRIPTION
This PR fixes a couple of instruction errors I noticed whilst running through `labs/intro/python/lab-02`.

1. Missing command for `cd stack-1`
2. Incorrect command `pulumi config set required_value = "i-am-required"` results in error `error: accepts between 1 and 2 arg(s), received 3`